### PR TITLE
Correct license attribution

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2017, Office for National Statistics (https://www.ons.gov.uk)
+Copyright (c) 2017 Crown Copyright (Office for National Statistics)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Adds correct license attribution (Copyright (c) 2017 Crown Copyright (Office for National Statistics)) to the LICENSE.md file in line with ONS standards.