### PR TITLE
Add Cloud Foundry curated doc guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ interest, best practices and continue to improve the experience of engineers at 
 ### Guides
 
 * [Standards](standards/README.md)
+* [Cloud Foundry](cloud-foundry/README.md)
 
 ### Licence
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-Software Engineer Community
-===========================
+# Software Engineer Community
 
 The software engineer community at ONS meets regularly to discuss areas of shared
 interest, best practices and continue to improve the experience of engineers at ONS.
 
-### Guides
+
+## Guides
 
 * [Standards](standards/README.md)
-* [Cloud Foundry](cloud-foundry/README.md)
+* [Cloud Foundry](cloud-foundry/README.md) - Getting started, and curated list of documentation
 
-### Licence
+
+## Licence
 
 Copyright ©‎ 2017, Office for National Statistics (https://www.ons.gov.uk)
 

--- a/cloud-foundry/README.md
+++ b/cloud-foundry/README.md
@@ -4,7 +4,7 @@ Cloud Foundry
 > Please note. This guide is a currated list of information tailored to use of Cloud Foundry (hereon referred to as `cf`) within ONS. It does not attempt to replicate information already available via the internet or reinvent wheels.
 
   - [concepts](#concepts)
-  - [cloud foundry cli tool](#cloud-foundry-cli-tool)
+  - [cloud foundry cli tool](#cloud-foundry-command-line-tool)
   - [deploying apps](#deploying-apps)
   - [see also](#see-also)
 

--- a/cloud-foundry/README.md
+++ b/cloud-foundry/README.md
@@ -1,0 +1,45 @@
+Cloud Foundry
+=============
+
+> Please note. This guide is a currated list of information tailored to use of Cloud Foundry (hereon referred to as `cf`) within ONS. It does not attempt to replicate information already available via the internet or reinvent wheels.
+
+  - [concepts](#concepts)
+  - [cloud foundry cli tool](#cloud-foundry-cli-tool)
+  - [deploying apps](#deploying-apps)
+  - [see also](#see-also)
+
+## Concepts
+
+General `cf` concepts and primers on the architecture if you're interested can be found in the [official docs](https://docs.cloudfoundry.org/concepts/)
+
+Highlights:
+
+  - [cloud foundry overview](https://docs.cloudfoundry.org/concepts/overview.html)
+  - [orgs, spaces, roles and permissions](https://docs.cloudfoundry.org/concepts/roles.html)
+
+
+## Cloud Foundry command line tool
+
+Most of your interaction with `cf` outside of a ci pipeline will be more than likely using the `cf cli` tool. Again, the [official cli docs](https://docs.cloudfoundry.org/cf-cli/) are a good place to start.
+
+Highlights:
+
+  - [getting started with the cli](https://docs.cloudfoundry.org/cf-cli/getting-started.html)
+  - [full cf cli refence](http://cli.cloudfoundry.org/en-US/cf/) - full official command reference
+
+
+## Deploying apps
+
+A good overview of the concepts and basic practice of deploying apps is covered in the [official docs under 'deploying and managing applications'](https://docs.cloudfoundry.org/devguide/deploy-apps/)
+
+Highlights:
+
+  - [considerations for designing and running apps](https://docs.cloudfoundry.org/devguide/deploy-apps/prepare-to-deploy.html)
+  - [deploy an application](https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html)
+  - [starting, restarting and restaging](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html)
+  - [application manifests](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html)
+
+
+## See Also
+
+  - [GDS Goverment PaaS 12 Factor and developing](https://docs.cloud.service.gov.uk/#12-factor-application-principles) - a good summary of the [12 factor](https://12factor.net) and how they related to a `cf` based environment as well as a general write up of `cf` concepts and principals.

--- a/cloud-foundry/README.md
+++ b/cloud-foundry/README.md
@@ -1,12 +1,12 @@
-Cloud Foundry
-=============
+# Cloud Foundry
 
-> Please note. This guide is a currated list of information tailored to use of Cloud Foundry (hereon referred to as `cf`) within ONS. It does not attempt to replicate information already available via the internet or reinvent wheels.
+> Please note. This guide is a curated list of information tailored to use of Cloud Foundry (hereon referred to as `cf`) within ONS. It does not attempt to replicate information already available via the internet or reinvent wheels.
 
-  - [concepts](#concepts)
-  - [cloud foundry cli tool](#cloud-foundry-command-line-tool)
-  - [deploying apps](#deploying-apps)
-  - [see also](#see-also)
+- [Concepts](#concepts)
+- [Cloud foundry cli tool](#cloud-foundry-command-line-tool)
+- [Deploying apps](#deploying-apps)
+- [See also](#see-also)
+
 
 ## Concepts
 
@@ -14,8 +14,8 @@ General `cf` concepts and primers on the architecture if you're interested can b
 
 Highlights:
 
-  - [cloud foundry overview](https://docs.cloudfoundry.org/concepts/overview.html)
-  - [orgs, spaces, roles and permissions](https://docs.cloudfoundry.org/concepts/roles.html)
+- [Cloud foundry overview](https://docs.cloudfoundry.org/concepts/overview.html)
+- [Orgs, spaces, roles and permissions](https://docs.cloudfoundry.org/concepts/roles.html)
 
 
 ## Cloud Foundry command line tool
@@ -24,8 +24,8 @@ Most of your interaction with `cf` outside of a ci pipeline will be more than li
 
 Highlights:
 
-  - [getting started with the cli](https://docs.cloudfoundry.org/cf-cli/getting-started.html)
-  - [full cf cli refence](http://cli.cloudfoundry.org/en-US/cf/) - full official command reference
+- [Getting started with the cli](https://docs.cloudfoundry.org/cf-cli/getting-started.html)
+- [Full official cf cli refence](http://cli.cloudfoundry.org/en-US/cf/)
 
 
 ## Deploying apps
@@ -34,12 +34,13 @@ A good overview of the concepts and basic practice of deploying apps is covered 
 
 Highlights:
 
-  - [considerations for designing and running apps](https://docs.cloudfoundry.org/devguide/deploy-apps/prepare-to-deploy.html)
-  - [deploy an application](https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html)
-  - [starting, restarting and restaging](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html)
-  - [application manifests](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html)
+- [Considerations for designing and running apps](https://docs.cloudfoundry.org/devguide/deploy-apps/prepare-to-deploy.html)
+- [Deploy an application](https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html)
+- [Starting, restarting and restaging](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html)
+- [Application manifests](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html)
 
 
 ## See Also
 
-  - [GDS Goverment PaaS 12 Factor and developing](https://docs.cloud.service.gov.uk/#12-factor-application-principles) - a good summary of the [12 factor](https://12factor.net) and how they related to a `cf` based environment as well as a general write up of `cf` concepts and principals.
+- [GDS Goverment PaaS 12 Factor and developing](https://docs.cloud.service.gov.uk/#12-factor-application-principles) - a good summary of the [12 factor](https://12factor.net) and how they related to a `cf` based environment as well as a general write up of `cf` concepts and principals. It's worth noting that not everything applies to our current environments (e.g. some backing services aren't available and we don't have paid plans etc)
+- [Software Engineering Community standards](../standards/README.md) - usual SE Community standards apply to code created for `cf` deployments.


### PR DESCRIPTION
Initial draft of curated documentation for Cloud Foundry and how it pertains to usage at ONS.

Mostly links to most useful cf official docs as well as some from GDS.

Will be expanded in future PRs to add more specific guidance where existing internet available docs are not sufficient or require amendment/clarification to avoid misleading.