### PR TITLE
Add continuous integration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ interest, best practices and continue to improve the experience of engineers at 
 
 * [Standards](standards/README.md)
 * [Cloud Foundry](cloud-foundry/README.md) - Getting started, and curated list of documentation
-
+* [Workflow](workflow/README.md)
 
 ## Licence
 

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -1,0 +1,11 @@
+# Workflow
+
+## Table of Contents
+1. [Updating Continuous Integration](continuous_integration.md)
+
+
+## Overview
+These docs give guidance and describe a way of working as software engineers. They are suggested practices rather than the golden rule.
+
+The practices described here are not final and should be continuously reviewed and updated. All software engineers should have a stake
+in sharing, reviewing, updating the practices.

--- a/workflow/continuous_integration.md
+++ b/workflow/continuous_integration.md
@@ -1,0 +1,37 @@
+# Continuous Integration (CI)
+Changes merged into master should be deployed automatically and tested. Preventative action should be taken to prevent merging changes that could fail continuous integration.
+
+## Failing Continuous Integration
+When CI fails it should be classed as a high priority to fix and make it stable again. This is because:
+
+* It may block the flow of the pipeline potentially blocking production releases
+* It may prevent other developers from getting accurate feedback from the pipeline for their changes
+
+## Actions
+
+1. Make the team aware of failure e.g. stand-ups, Slack, dashboard, shouting
+1. Re-run tests to check if it's a flaky test (if it is flaky schedule time to fix it)
+1. Triage the issue to get an understanding of why it's failing
+1. Consider backing out the changes if the fix will take a long time
+1. Write tests to catch the failures earlier in the process
+1. Fix issues and raise a pull request
+
+## Before raising a Pull Request
+It is important to remember how code changes could affect continuous integration.
+
+Any CI changes should be made as early as possible, ideally before raising a pull request.
+
+## Examples of CI changes that could be made independently before merging any code changes are:
+
+* Adding/changing environment variables
+* Adding a new service
+* Adding a new Cloudfoundry service
+* Changing the versions of the build tools used
+* A Git repository is renamed
+
+## Examples of CI changes which may need to be updated after merges are:
+
+* Build scripts added/removed
+* Changing the build tools used
+* Removing a service
+* A change to how the tests run


### PR DESCRIPTION
# Background
We should have some guidance around continuous integration and why we
use it. CI should be embedded in the team to get fast, reliable feedback
on the code you are writing.

# Summary
* What is continuous integration guidance
* What happens when it fails
* How you can resolve failures
* Considerations when making changes that will affect it
* Examples of things that may need to be updated

# How to review
* Check to see if the workflow makes sense and is appropriate
* Discuss at community of practice and agree