### PR TITLE
Create Induction of Software Engineers at ONS - please read and review, thanks.

### DIFF
--- a/Induction of Software Engineers at ONS
+++ b/Induction of Software Engineers at ONS
@@ -1,0 +1,58 @@
+# Induction to ONS - A Guide for the Induction of Software Engineers
+
+This document is intended to give software engineer team leads some guidance on how to introduce new software enginners to ONS and all its facilities. This is mainly intended for permanent staff, since it will include reference to subjects such as flexi terminals, but it could also be used for software engineer contractors to a large extent. 
+
+The sections below list things that would be useful for new starters to be shown/given.
+
+## General Physical Environment
+
+To help new starters to become familiar with the ONS office buildings and to help them get to know whos who in their team:
+- a tour of the relevant building(s) and a map of them.
+- fire escape routes.
+- flexi terminals and how to use them.
+- where to buy food/drink (shop, canteen, etc) and where to keep food/drink (break out area, fridge).
+- a place to keep their personal things safe (locker/pedestal).
+- informal introductions to the staff who they will be sitting near to and/or working with.
+
+## Other Physical Environment 
+
+More specific/complex features of the physical environment:
+- smart meetings rooms and how to use them.
+- how to get things delivered to the office.
+- clean desk policy.
+- location of library and details of what facilities/services it offers.
+- location of local resources (if they are new to the area).
+
+## General Team Requirements
+
+To help new starters understand where their team fits into ONS as a whole, and how their team works together, what meetings to attend in their team, what facilities belong to their team, and so on:
+- a proper introduction to their team e.g. if there is a regular team meeting, where they can be formally introduced to everyone, this would be perfect.
+- a "buddy" i.e. a person in their team who they can go to as a first port of call, with any questions/problems/requests, during their first week.
+- an organisation chart (that is at the right level to include the names of the staff in their team). Ideally it would also have been updated to include the new starter.
+- the names of customers to the team (these could be names of people and/or organisations). If the customers also work in ONS then an informal introduction to them would also be helpful.
+- what software the team makes for their customers and why e.g. quick demo of relevant software and an overview of what the customers use it for.
+- invitations to the Software Engineer Community of Practice meetings, team meetings/stand-ups, and other regular meetings, which the team attends. Make sure that they are added to relevant mailing lists for these and also for any regular communications that they will need to receive e.g. project newsletters.
+- flexi policies and other team policies (i.e. here's when we really need to be in, give x day's notice before taking leave, here's where we check in/out, how to mark annual leave taken).
+- team's favourite bookmarks (these could be stored in a document or sent in an email).
+
+## General Software Requirements
+
+To help new starters to become familiar with the software/systems that they will need to use for general (non-development) purposes:
+- Reggie
+- The Service Desk
+- Outlook
+- Skype
+- Oracle Fusion
+- Flexi Pi
+- what document management software the team uses e.g. SharePoint, Confluence
+- what training software the team uses and how to get a licence for it e.g. Pluralsight, Safari (email DST.Professional.Development@ons.gov.uk and request it)
+- what communication software the team uses and how to get set up on it e.g. Slack, Yammer
+
+## Software Development Requirements
+
+To help new software engineers to get started with developing software:
+- an off-network laptop.
+- where to find relevant development software that their team uses.
+- where to find development standards documentation i.e. this repository (https://github.com/ONSdigital/software-engineer-community) etc.
+- help to contribute some software or other development at the first opportunity. Make sure that this is celebrated in the team.
+- a software road map (if there is one available).


### PR DESCRIPTION
This document is intended to give software engineer team leads some guidance on how to introduce new software enginners to ONS and all its facilities.